### PR TITLE
change return of mptcp use to a "if/else" to catch the new /proc layout and fallback to the old, if needed

### DIFF
--- a/inc/mptcp.inc.php
+++ b/inc/mptcp.inc.php
@@ -53,7 +53,11 @@
 		$ip_hex = strtoupper($ip_hex);
 
 		// Return if you're connected via MPTCP!
-		return strpos(shell_exec("cat /proc/net/mptcp"), $ip_hex . ':' . $port_hex) ? true : false;
+                if (file_exists("/proc/net/mptcp_net/mptcp")) {
+                        return strpos(shell_exec("cat /proc/net/mptcp_net/mptcp"), $ip_hex . ':' . $port_hex) ? true : false;
+                } else {
+                        return strpos(shell_exec("cat /proc/net/mptcp"), $ip_hex . ':' . $port_hex) ? true : false;
+                }
 	}
 
 	// OS 'enumerations'


### PR DESCRIPTION
without it, mptcp will be not detected and the site reports "no". So only mptcp v0.90 and earlier will work , but no new ones.

Signed-off-by: Ronny Boesger <ronny@boesger.de